### PR TITLE
add name output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ data "aws_iam_policy_document" "autoscaler" {
 }
 
 resource "aws_iam_role_policy" "autoscaler" {
-  name   = "${module.default.id}-autoscaler-dynamo"
+  name   = "${module.default.id}-autoscaler-dynamodb"
   role   = "${aws_iam_role.autoscaler.id}"
   policy = "${data.aws_iam_policy_document.autoscaler.json}"
 }

--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "aws_iam_role_policy" "autoscaler_cloudwatch" {
   policy = "${data.aws_iam_policy_document.autoscaler_cloudwatch.json}"
 }
 
-data "aws_iam_role" "autoscale_service_linked_role" {
+data "aws_iam_role" "autoscale_service" {
   name = "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
 }
 
@@ -113,7 +113,7 @@ resource "aws_appautoscaling_target" "read_target" {
   max_capacity       = "${var.autoscale_max_read_capacity}"
   min_capacity       = "${var.autoscale_min_read_capacity}"
   resource_id        = "table/${module.default.id}"
-  role_arn           = "${data.aws_iam_role.autoscale_service_linked_role.arn}"
+  role_arn           = "${data.aws_iam_role.autoscale_service.arn}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -138,7 +138,7 @@ resource "aws_appautoscaling_target" "write_target" {
   max_capacity       = "${var.autoscale_max_write_capacity}"
   min_capacity       = "${var.autoscale_min_write_capacity}"
   resource_id        = "table/${module.default.id}"
-  role_arn           = "${data.aws_iam_role.autoscale_service_linked_role.arn}"
+  role_arn           = "${data.aws_iam_role.autoscale_service.arn}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 }

--- a/main.tf
+++ b/main.tf
@@ -105,11 +105,15 @@ resource "aws_iam_role_policy" "autoscaler_cloudwatch" {
   policy = "${data.aws_iam_policy_document.autoscaler_cloudwatch.json}"
 }
 
+data "aws_iam_role" "autoscale_service_linked_role" {
+  name = "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
+}
+
 resource "aws_appautoscaling_target" "read_target" {
   max_capacity       = "${var.autoscale_max_read_capacity}"
   min_capacity       = "${var.autoscale_min_read_capacity}"
   resource_id        = "table/${module.default.id}"
-  role_arn           = "${aws_iam_role.autoscaler.arn}"
+  role_arn           = "${data.aws_iam_role.autoscale_service_linked_role.arn}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -134,7 +138,7 @@ resource "aws_appautoscaling_target" "write_target" {
   max_capacity       = "${var.autoscale_max_write_capacity}"
   min_capacity       = "${var.autoscale_min_write_capacity}"
   resource_id        = "table/${module.default.id}"
-  role_arn           = "${aws_iam_role.autoscaler.arn}"
+  role_arn           = "${data.aws_iam_role.autoscale_service_linked_role.arn}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 }

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "autoscaler" {
       "dynamodb:UpdateTable",
     ]
 
-    resources = ["arn:aws:dynamodb:${var.region}:${data.aws_caller_identity.current.account_id}:table/${module.default.id}"]
+    resources = ["${aws_dynamodb_table.default.arn}"]
 
     effect = "Allow"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "table_name" {
+  value = "${aws_dynamodb_table.default.name}"
+}
+
 output "table_id" {
   value = "${aws_dynamodb_table.default.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "region" {
-  type = "string"
-}
-
 variable "name" {
   type = "string"
 }


### PR DESCRIPTION
## what
* Add table name output
* Use ARN
* Deprecate `region`
* Use `AWSServiceRoleForApplicationAutoScaling_DynamoDBTable` arn

## why
* Name is useful for passing to other modules
* Use ARN to be precise and reduce variables
* Service Role needed for Idepotent executions

## references
* https://github.com/terraform-providers/terraform-provider-aws/issues/2750
