### PR TITLE
Enable encryption and do not request a specific role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "aws_dynamodb_table" "default" {
   range_key      = "${var.range_key}"
 
   server_side_encryption {
-    enabled = "true"
+    enabled = "${var.enable_encryption}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -105,15 +105,10 @@ resource "aws_iam_role_policy" "autoscaler_cloudwatch" {
   policy = "${data.aws_iam_policy_document.autoscaler_cloudwatch.json}"
 }
 
-data "aws_iam_role" "autoscale_service" {
-  name = "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
-}
-
 resource "aws_appautoscaling_target" "read_target" {
   max_capacity       = "${var.autoscale_max_read_capacity}"
   min_capacity       = "${var.autoscale_min_read_capacity}"
   resource_id        = "table/${module.default.id}"
-  role_arn           = "${data.aws_iam_role.autoscale_service.arn}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -138,7 +133,6 @@ resource "aws_appautoscaling_target" "write_target" {
   max_capacity       = "${var.autoscale_max_write_capacity}"
   min_capacity       = "${var.autoscale_min_write_capacity}"
   resource_id        = "table/${module.default.id}"
-  role_arn           = "${data.aws_iam_role.autoscale_service.arn}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 }

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,10 @@ resource "aws_dynamodb_table" "default" {
   hash_key       = "${var.hash_key}"
   range_key      = "${var.range_key}"
 
+  server_side_encryption {
+    enabled = "true"
+  }
+
   lifecycle {
     ignore_changes = ["read_capacity", "write_capacity"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,10 @@ variable "stage" {
   type = "string"
 }
 
+variable "enable_encryption" {
+  default = "true"
+}
+
 variable "attributes" {
   type    = "list"
   default = []


### PR DESCRIPTION
## what
* Enable encryption as rest. 
* Do not pin to the `AWSServiceRoleForApplicationAutoScaling_DynamoDBTable` role.

## why
* It may not exist in the account. https://github.com/terraform-providers/terraform-provider-aws/issues/2844 
* It was fixed in Terraform `1.11` (Requires AWS provider 1.11: https://github.com/terraform-providers/terraform-provider-aws/pull/3303)