### PR TITLE
read/write targets now explicitly depend on dynamo_table

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_iam_role_policy" "autoscaler_cloudwatch" {
 resource "aws_appautoscaling_target" "read_target" {
   max_capacity       = "${var.autoscale_max_read_capacity}"
   min_capacity       = "${var.autoscale_min_read_capacity}"
-  resource_id        = "table/${module.default.id}"
+  resource_id        = "table/${aws_dynamodb_table.default.name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
 }
@@ -136,7 +136,7 @@ resource "aws_appautoscaling_policy" "read_policy" {
 resource "aws_appautoscaling_target" "write_target" {
   max_capacity       = "${var.autoscale_max_write_capacity}"
   min_capacity       = "${var.autoscale_min_write_capacity}"
-  resource_id        = "table/${module.default.id}"
+  resource_id        = "table/${aws_dynamodb_table.default.name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
   service_namespace  = "dynamodb"
 }


### PR DESCRIPTION
## what

read/write targets now explicitly depend on dynamo_table

## why
This ensures Terraform creates the resources in the correct order. Previously Terraform would create them asynchronously leading to race conditions:

```
Error: Error applying plan:

2 error(s) occurred:

* module.teleport.module.dynamodb_table.aws_appautoscaling_target.write_target: 1 error(s) occurred:

* aws_appautoscaling_target.write_target: Error creating application autoscaling target: ValidationException: DynamoDB table does not exist: table/namespace-prod-application
	status code: 400, request id: 4a0a959e-299a-11e8-a8c6-abb8a03f8486
* module.teleport.module.dynamodb_table.aws_appautoscaling_target.read_target: 1 error(s) occurred:

* aws_appautoscaling_target.read_target: Error creating application autoscaling target: ValidationException: DynamoDB table does not exist: table/namespace-prod-application
	status code: 400, request id: 4a089978-299a-11e8-ba96-33fb82e704af
```

[ch9491]