### PR TITLE
Add global secondary indexes to `terraform-aws-dynamodb-autoscaler`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 .terraform/
 
 .idea
-terraform-aws-dynamodb.iml
+*.iml

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ module "dynamodb_table" {
   name                         = "cluster"
   hash_key                     = "HashKey"
   range_key                    = "RangeKey"
-  autoscale_write_target       = 10
-  autoscale_read_target        = 10
+  autoscale_write_target       = 50
+  autoscale_read_target        = 50
   autoscale_min_read_capacity  = 5
   autoscale_max_read_capacity  = 20
   autoscale_min_write_capacity = 5
@@ -35,8 +35,8 @@ module "dynamodb_table" {
   name                         = "cluster"
   hash_key                     = "HashKey"
   range_key                    = "RangeKey"
-  autoscale_write_target       = 10
-  autoscale_read_target        = 10
+  autoscale_write_target       = 50
+  autoscale_read_target        = 50
   autoscale_min_read_capacity  = 5
   autoscale_max_read_capacity  = 20
   autoscale_min_write_capacity = 5
@@ -87,8 +87,8 @@ module "dynamodb_table" {
 | `attributes`                    | `[]`         | Additional attributes (_e.g._ `policy` or `role`)                              | No       |
 | `tags`                          | `{}`         | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                           | No       |
 | `delimiter`                     | `-`          | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`    | No       |
-| `autoscale_write_target`        | `10`         | The target value for DynamoDB write autoscaling                                | No       |
-| `autoscale_read_target`         | `10`         | The target value for DynamoDB read autoscaling                                 | No       |
+| `autoscale_write_target`        | `50`         | The target value (in %) for DynamoDB write autoscaling                         | No       |
+| `autoscale_read_target`         | `50`         | The target value (in %) for DynamoDB read autoscaling                          | No       |
 | `autoscale_min_read_capacity`   | `5`          | DynamoDB autoscaling min read capacity                                         | No       |
 | `autoscale_max_read_capacity`   | `20`         | DynamoDB autoscaling max read capacity                                         | No       |
 | `autoscale_min_write_capacity`  | `5`          | DynamoDB autoscaling min write capacity                                        | No       |
@@ -99,6 +99,7 @@ module "dynamodb_table" {
 
 
 ## A note about DynamoDB attributes
+
 Only define attributes on the table object that are going to be used as:
 
 * Table hash key or range key

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ or [hire us][hire] to help build your next cloud-platform.
   [community]: https://github.com/cloudposse/
   [hire]: http://cloudposse.com/contact/
 
-### Contributors
 
+## Contributors
 
 | [![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] | [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |
 |-------------------------------------------------------|------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ module "dynamodb_table" {
       {
         name               = "DailyAverageIndex"
         hash_key           = "DailyAverage"
-        write_capacity     = 10
-        read_capacity      = 10
+        write_capacity     = 5
+        read_capacity      = 5
         projection_type    = "KEYS_ONLY"
       },
       {
         name               = "HighWaterIndex"
         hash_key           = "HighWater"
-        write_capacity     = 10
-        read_capacity      = 10
+        write_capacity     = 5
+        read_capacity      = 5
         projection_type    = "KEYS_ONLY"
       }
   ]
@@ -94,8 +94,8 @@ module "dynamodb_table" {
 | `autoscale_min_write_capacity`  | `5`          | DynamoDB autoscaling min write capacity                                        | No       |
 | `autoscale_max_write_capacity`  | `20`         | DynamoDB autoscaling max write capacity                                        | No       |
 | `enable_autoscaler`             | `true`       | Flag to enable/disable DynamoDB autoscaling                                    | No       |
-| `dynamodb_attributes`           | `[]`         | List of maps, that describe extra DynamoDB attributes                          | No       |
-| `global_secondary_index_map`    | `[]`         | List of maps, that describes additional secondary index properties             | No       |
+| `dynamodb_attributes`           | `[]`         | List of maps that describe extra DynamoDB attributes                           | No       |
+| `global_secondary_index_map`    | `[]`         | List of maps that describes additional secondary index properties              | No       |
 
 
 ## A note about DynamoDB attributes

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,11 @@ locals {
   ]
 }
 
+resource "null_resource" "global_secondary_indexes" {
+  count    = "${length(var.global_secondary_index_map)}"
+  triggers = "${var.global_secondary_index_map[count.index]}"
+}
+
 resource "aws_dynamodb_table" "default" {
   name           = "${module.dynamodb_label.id}"
   read_capacity  = "${var.autoscale_min_read_capacity}"
@@ -48,7 +53,7 @@ resource "aws_dynamodb_table" "default" {
 }
 
 module "dynamodb_autoscaler" {
-  source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=tags/0.1.1"
+  source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=tags/0.2.0"
   enabled                      = "${var.enable_autoscaler}"
   namespace                    = "${var.namespace}"
   stage                        = "${var.stage}"
@@ -57,6 +62,7 @@ module "dynamodb_autoscaler" {
   attributes                   = "${var.attributes}"
   dynamodb_table_name          = "${aws_dynamodb_table.default.id}"
   dynamodb_table_arn           = "${aws_dynamodb_table.default.arn}"
+  dynamodb_indexes             = ["${null_resource.global_secondary_indexes.*.triggers.name}"]
   autoscale_write_target       = "${var.autoscale_write_target}"
   autoscale_read_target        = "${var.autoscale_read_target}"
   autoscale_min_read_capacity  = "${var.autoscale_min_read_capacity}"

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_dynamodb_table" "default" {
 }
 
 module "dynamodb_autoscaler" {
-  source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=tags/0.2.0"
+  source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=tags/0.2.1"
   enabled                      = "${var.enable_autoscaler}"
   namespace                    = "${var.namespace}"
   stage                        = "${var.stage}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "table_id" {
 output "table_arn" {
   value = "${aws_dynamodb_table.default.arn}"
 }
+
+output "global_secondary_index_names" {
+  value = ["${null_resource.global_secondary_indexes.*.triggers.name}"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -32,13 +32,13 @@ variable "tags" {
 }
 
 variable "autoscale_write_target" {
-  default     = 10
-  description = "The target value for DynamoDB write autoscaling"
+  default     = 50
+  description = "The target value (in %) for DynamoDB write autoscaling"
 }
 
 variable "autoscale_read_target" {
-  default     = 10
-  description = "The target value for DynamoDB read autoscaling"
+  default     = 50
+  description = "The target value (in %) for DynamoDB read autoscaling"
 }
 
 variable "autoscale_min_read_capacity" {
@@ -92,7 +92,7 @@ variable "enable_autoscaler" {
 variable "dynamodb_attributes" {
   type        = "list"
   default     = []
-  description = "Additional dynamodb attributes in the form of a list of mapped values"
+  description = "Additional DynamoDB attributes in the form of a list of mapped values"
 }
 
 variable "global_secondary_index_map" {

--- a/variables.tf
+++ b/variables.tf
@@ -90,13 +90,41 @@ variable "enable_autoscaler" {
 }
 
 variable "dynamodb_attributes" {
-  type        = "list"
-  default     = []
+  type = "list"
+
+  default = [
+    {
+      name = "DailyAverage"
+      type = "N"
+    },
+    {
+      name = "HighWater"
+      type = "N"
+    },
+  ]
+
   description = "Additional DynamoDB attributes in the form of a list of mapped values"
 }
 
 variable "global_secondary_index_map" {
-  type        = "list"
-  default     = []
+  type = "list"
+
+  default = [
+    {
+      name            = "DailyAverageIndex"
+      hash_key        = "DailyAverage"
+      write_capacity  = 10
+      read_capacity   = 10
+      projection_type = "KEYS_ONLY"
+    },
+    {
+      name            = "HighWaterIndex"
+      hash_key        = "HighWater"
+      write_capacity  = 10
+      read_capacity   = 10
+      projection_type = "KEYS_ONLY"
+    },
+  ]
+
   description = "Additional global secondary indexes in the form of a list of mapped values"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,41 +90,13 @@ variable "enable_autoscaler" {
 }
 
 variable "dynamodb_attributes" {
-  type = "list"
-
-  default = [
-    {
-      name = "DailyAverage"
-      type = "N"
-    },
-    {
-      name = "HighWater"
-      type = "N"
-    },
-  ]
-
+  type        = "list"
+  default     = []
   description = "Additional DynamoDB attributes in the form of a list of mapped values"
 }
 
 variable "global_secondary_index_map" {
-  type = "list"
-
-  default = [
-    {
-      name            = "DailyAverageIndex"
-      hash_key        = "DailyAverage"
-      write_capacity  = 10
-      read_capacity   = 10
-      projection_type = "KEYS_ONLY"
-    },
-    {
-      name            = "HighWaterIndex"
-      hash_key        = "HighWater"
-      write_capacity  = 10
-      read_capacity   = 10
-      projection_type = "KEYS_ONLY"
-    },
-  ]
-
+  type        = "list"
+  default     = []
   description = "Additional global secondary indexes in the form of a list of mapped values"
 }


### PR DESCRIPTION
## what
* Add global secondary indexes to `terraform-aws-dynamodb-autoscaler`

## why
* Indexes need to be auto-scaled as well

## terraform apply
```
Apply complete! Resources: 19 added, 0 changed, 0 destroyed.

Outputs:

global_secondary_index_names = [
    DailyAverageIndex,
    HighWaterIndex
]
table_arn = arn:aws:dynamodb:us-east-1:XXXXXXXXXXXX:table/cp-prod-app
table_id = cp-prod-app
table_name = cp-prod-app
```

![image](https://user-images.githubusercontent.com/7356997/40275296-acbd938a-5bb9-11e8-8a03-8783c7bac2ea.png)

![image](https://user-images.githubusercontent.com/7356997/40275298-b4a385b4-5bb9-11e8-933e-2b155af658a0.png)

