### PR TITLE
Add support for `non_key_attributes`. Add examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
-# Compiled files
+#  Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
 *.tfstate
-*.tfstate.backup
+*.tfstate.*
 
-# Module directory
-.terraform/
+# .tfvars files
+*.tfvars
 
-.idea
-*.iml
+**/.idea
+**/*.iml
 
-.build-harness
-build-harness
+**/.build-harness
+**/build-harness

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ module "dynamodb_table" {
 }
 ```
 
-## Advanced Usage - with additional attributes and indexes
+## Advanced Usage
+
+With additional attributes, global secondary indexes and `non_key_attributes` (see [examples/complete](examples/complete)).
 
 ```hcl
 module "dynamodb_table" {
@@ -68,32 +70,34 @@ module "dynamodb_table" {
   autoscale_max_write_capacity = 20
   enable_autoscaler            = "true"
 
-  dynamodb_attributes          = [
-      {
-        name = "DailyAverage"
-        type = "N"
-      },
-      {
-        name = "HighWater"
-        type = "N"
-      }
-    ]
+  dynamodb_attributes = [
+    {
+      name = "DailyAverage"
+      type = "N"
+    },
+    {
+      name = "HighWater"
+      type = "N"
+    },
+  ]
 
-  global_secondary_index_map   = [
-      {
-        name               = "DailyAverageIndex"
-        hash_key           = "DailyAverage"
-        write_capacity     = 5
-        read_capacity      = 5
-        projection_type    = "KEYS_ONLY"
-      },
-      {
-        name               = "HighWaterIndex"
-        hash_key           = "HighWater"
-        write_capacity     = 5
-        read_capacity      = 5
-        projection_type    = "KEYS_ONLY"
-      }
+  global_secondary_index_map = [
+    {
+      name               = "DailyAverageIndex"
+      hash_key           = "DailyAverage"
+      range_key          = "HighWater"
+      write_capacity     = 5
+      read_capacity      = 5
+      projection_type    = "INCLUDE"
+      non_key_attributes = ["HashKey", "RangeKey"]
+    },
+    {
+      name            = "HighWaterIndex"
+      hash_key        = "HighWater"
+      write_capacity  = 5
+      read_capacity   = 5
+      projection_type = "KEYS_ONLY"
+    },
   ]
 }
 ```

--- a/README.yaml
+++ b/README.yaml
@@ -81,7 +81,9 @@ usage: |-
   }
   ```
 
-  ## Advanced Usage - with additional attributes and indexes
+  ## Advanced Usage
+
+  With additional attributes, global secondary indexes and `non_key_attributes` (see [examples/complete](examples/complete)).
 
   ```hcl
   module "dynamodb_table" {
@@ -99,32 +101,34 @@ usage: |-
     autoscale_max_write_capacity = 20
     enable_autoscaler            = "true"
 
-    dynamodb_attributes          = [
-        {
-          name = "DailyAverage"
-          type = "N"
-        },
-        {
-          name = "HighWater"
-          type = "N"
-        }
-      ]
+    dynamodb_attributes = [
+      {
+        name = "DailyAverage"
+        type = "N"
+      },
+      {
+        name = "HighWater"
+        type = "N"
+      },
+    ]
 
-    global_secondary_index_map   = [
-        {
-          name               = "DailyAverageIndex"
-          hash_key           = "DailyAverage"
-          write_capacity     = 5
-          read_capacity      = 5
-          projection_type    = "KEYS_ONLY"
-        },
-        {
-          name               = "HighWaterIndex"
-          hash_key           = "HighWater"
-          write_capacity     = 5
-          read_capacity      = 5
-          projection_type    = "KEYS_ONLY"
-        }
+    global_secondary_index_map = [
+      {
+        name               = "DailyAverageIndex"
+        hash_key           = "DailyAverage"
+        range_key          = "HighWater"
+        write_capacity     = 5
+        read_capacity      = 5
+        projection_type    = "INCLUDE"
+        non_key_attributes = ["HashKey", "RangeKey"]
+      },
+      {
+        name            = "HighWaterIndex"
+        hash_key        = "HighWater"
+        write_capacity  = 5
+        read_capacity   = 5
+        projection_type = "KEYS_ONLY"
+      },
     ]
   }
   ```

--- a/examples/complete/.gitignore
+++ b/examples/complete/.gitignore
@@ -1,0 +1,5 @@
+.terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfvars

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,45 @@
+module "dynamodb_table" {
+  source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb.git?ref=master"
+  namespace                    = "eg"
+  stage                        = "dev"
+  name                         = "cluster"
+  hash_key                     = "HashKey"
+  range_key                    = "RangeKey"
+  autoscale_write_target       = 50
+  autoscale_read_target        = 50
+  autoscale_min_read_capacity  = 5
+  autoscale_max_read_capacity  = 20
+  autoscale_min_write_capacity = 5
+  autoscale_max_write_capacity = 20
+  enable_autoscaler            = "true"
+
+  dynamodb_attributes = [
+    {
+      name = "DailyAverage"
+      type = "N"
+    },
+    {
+      name = "HighWater"
+      type = "N"
+    },
+  ]
+
+  global_secondary_index_map = [
+    {
+      name               = "DailyAverageIndex"
+      hash_key           = "DailyAverage"
+      range_key          = "HighWater"
+      write_capacity     = 5
+      read_capacity      = 5
+      projection_type    = "INCLUDE"
+      non_key_attributes = ["HashKey", "RangeKey"]
+    },
+    {
+      name            = "HighWaterIndex"
+      hash_key        = "HighWater"
+      write_capacity  = 5
+      read_capacity   = 5
+      projection_type = "KEYS_ONLY"
+    },
+  ]
+}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,29 +1,29 @@
 output "table_name" {
-  value       = "${aws_dynamodb_table.default.name}"
+  value       = "${module.dynamodb_table.table_name}"
   description = "DynamoDB table name"
 }
 
 output "table_id" {
-  value       = "${aws_dynamodb_table.default.id}"
+  value       = "${module.dynamodb_table.table_id}"
   description = "DynamoDB table ID"
 }
 
 output "table_arn" {
-  value       = "${aws_dynamodb_table.default.arn}"
+  value       = "${module.dynamodb_table.table_arn}"
   description = "DynamoDB table ARN"
 }
 
 output "global_secondary_index_names" {
-  value       = ["${null_resource.global_secondary_indexe_names.*.triggers.name}"]
+  value       = "${module.dynamodb_table.global_secondary_index_names}"
   description = "DynamoDB secondary index names"
 }
 
 output "table_stream_arn" {
-  value       = "${aws_dynamodb_table.default.stream_arn}"
+  value       = "${module.dynamodb_table.table_stream_arn}"
   description = "DynamoDB table stream ARN"
 }
 
 output "table_stream_label" {
-  value       = "${aws_dynamodb_table.default.stream_label}"
+  value       = "${module.dynamodb_table.table_stream_label}"
   description = "DynamoDB table stream label"
 }

--- a/main.tf
+++ b/main.tf
@@ -28,9 +28,13 @@ locals {
   attributes_final = "${slice(local.attributes, local.from_index, length(local.attributes))}"
 }
 
-resource "null_resource" "global_secondary_indexes" {
-  count    = "${length(var.global_secondary_index_map)}"
-  triggers = "${var.global_secondary_index_map[count.index]}"
+resource "null_resource" "global_secondary_indexe_names" {
+  count = "${length(var.global_secondary_index_map)}"
+
+  # Convert the multi-item `global_secondary_index_map` into a simple `map` with just one item `name` since `triggers` does not support `lists` in `maps` (which are used in `non_key_attributes`)
+  # See `examples/complete`
+  # https://www.terraform.io/docs/providers/aws/r/dynamodb_table.html#non_key_attributes-1
+  triggers = "${map("name", lookup(var.global_secondary_index_map[count.index], "name"))}"
 }
 
 resource "aws_dynamodb_table" "default" {
@@ -75,7 +79,7 @@ module "dynamodb_autoscaler" {
   attributes                   = "${var.attributes}"
   dynamodb_table_name          = "${aws_dynamodb_table.default.id}"
   dynamodb_table_arn           = "${aws_dynamodb_table.default.arn}"
-  dynamodb_indexes             = ["${null_resource.global_secondary_indexes.*.triggers.name}"]
+  dynamodb_indexes             = ["${null_resource.global_secondary_indexe_names.*.triggers.name}"]
   autoscale_write_target       = "${var.autoscale_write_target}"
   autoscale_read_target        = "${var.autoscale_read_target}"
   autoscale_min_read_capacity  = "${var.autoscale_min_read_capacity}"


### PR DESCRIPTION
## what
* Add support for `non_key_attributes`
* Add examples

## why
* Address https://github.com/cloudposse/terraform-aws-dynamodb/issues/14

## terraform apply

```
Apply complete! Resources: 19 added, 0 changed, 0 destroyed.

Outputs:

global_secondary_index_names = [
    DailyAverageIndex,
    HighWaterIndex
]
table_arn = arn:aws:dynamodb:us-east-1:XXXXXXXXXX:table/eg-dev-cluster
table_id = eg-dev-cluster
table_name = eg-dev-cluster
table_stream_arn =
table_stream_label =
```
