### PR TITLE
Add variables to specify data types for Hash and Range keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -168,10 +167,12 @@ Available targets:
 | enable_streams | Enable DynamoDB streams | string | `false` | no |
 | global_secondary_index_map | Additional global secondary indexes in the form of a list of mapped values | list | `<list>` | no |
 | hash_key | DynamoDB table Hash Key | string | - | yes |
+| hash_key_type | Hash Key type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data | string | `S` | no |
 | local_secondary_index_map | Additional local secondary indexes in the form of a list of mapped values | list | `<list>` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | range_key | DynamoDB table Range Key | string | `` | no |
+| range_key_type | Range Key type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data | string | `S` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`, `infra`) | string | - | yes |
 | stream_view_type | When an item in the table is modified, what information is written to the stream | string | `` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -18,10 +17,12 @@
 | enable_streams | Enable DynamoDB streams | string | `false` | no |
 | global_secondary_index_map | Additional global secondary indexes in the form of a list of mapped values | list | `<list>` | no |
 | hash_key | DynamoDB table Hash Key | string | - | yes |
+| hash_key_type | Hash Key type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data | string | `S` | no |
 | local_secondary_index_map | Additional local secondary indexes in the form of a list of mapped values | list | `<list>` | no |
 | name | Name  (e.g. `app` or `cluster`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | range_key | DynamoDB table Range Key | string | `` | no |
+| range_key_type | Range Key type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data | string | `S` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`, `infra`) | string | - | yes |
 | stream_view_type | When an item in the table is modified, what information is written to the stream | string | `` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "dynamodb_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -12,11 +12,11 @@ locals {
   attributes = [
     {
       name = "${var.range_key}"
-      type = "S"
+      type = "${var.range_key_type}"
     },
     {
       name = "${var.hash_key}"
-      type = "S"
+      type = "${var.hash_key_type}"
     },
     "${var.dynamodb_attributes}",
   ]
@@ -80,7 +80,7 @@ resource "aws_dynamodb_table" "default" {
 }
 
 module "dynamodb_autoscaler" {
-  source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=tags/0.2.4"
+  source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=tags/0.2.5"
   enabled                      = "${var.enable_autoscaler}"
   namespace                    = "${var.namespace}"
   stage                        = "${var.stage}"

--- a/variables.tf
+++ b/variables.tf
@@ -90,10 +90,22 @@ variable "hash_key" {
   description = "DynamoDB table Hash Key"
 }
 
+variable "hash_key_type" {
+  type        = "string"
+  default     = "S"
+  description = "Hash Key type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data"
+}
+
 variable "range_key" {
   type        = "string"
   default     = ""
   description = "DynamoDB table Range Key"
+}
+
+variable "range_key_type" {
+  type        = "string"
+  default     = "S"
+  description = "Range Key type, which must be a scalar type: `S`, `N`, or `B` for (S)tring, (N)umber or (B)inary data"
 }
 
 variable "ttl_attribute" {


### PR DESCRIPTION
## what
* Add variables to specify data types for Hash and Range keys

## why
* The primary keys (Hash and Range) can accept 3 data types: String, Number & Binary
* Closes #24 

## references
* https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html
