### PR TITLE
[Fix] Validation error when stream is disabled and stream view type is not empty string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_dynamodb_table" "default" {
   hash_key         = "${var.hash_key}"
   range_key        = "${var.range_key}"
   stream_enabled   = "${var.enable_streams}"
-  stream_view_type = "${var.stream_view_type}"
+  stream_view_type = "${var.enable_streams ? var.stream_view_type : ""}"
 
   server_side_encryption {
     enabled = "${var.enable_encryption}"

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_dynamodb_table" "default" {
   hash_key         = "${var.hash_key}"
   range_key        = "${var.range_key}"
   stream_enabled   = "${var.enable_streams}"
-  stream_view_type = "${var.enable_streams ? var.stream_view_type : ""}"
+  stream_view_type = "${var.enable_streams == "true" ? var.stream_view_type : ""}"
 
   server_side_encryption {
     enabled = "${var.enable_encryption}"


### PR DESCRIPTION
### What
Pass empty string to `stream_view_type` when streams are not enabled

### Why
If `enabled_stream = false` and `stream_view_type` is non empty, AWS dynamoDB gives validation error.

### References
https://github.com/terraform-providers/terraform-provider-aws/issues/1134