### PR TITLE
add billing_mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Available targets:
 | autoscale_min_write_capacity | DynamoDB autoscaling min write capacity | string | `5` | no |
 | autoscale_read_target | The target value (in %) for DynamoDB read autoscaling | string | `50` | no |
 | autoscale_write_target | The target value (in %) for DynamoDB write autoscaling | string | `50` | no |
+| billing_mode | DynamoDB Billing mode. Can be PROVISIONED or PAY_PER_REQUEST | string | `PROVISIONED` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes` | string | `-` | no |
 | dynamodb_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `<list>` | no |
 | enable_autoscaler | Flag to enable/disable DynamoDB autoscaling | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,6 +9,7 @@
 | autoscale_min_write_capacity | DynamoDB autoscaling min write capacity | string | `5` | no |
 | autoscale_read_target | The target value (in %) for DynamoDB read autoscaling | string | `50` | no |
 | autoscale_write_target | The target value (in %) for DynamoDB write autoscaling | string | `50` | no |
+| billing_mode | DynamoDB Billing mode. Can be PROVISIONED or PAY_PER_REQUEST | string | `PROVISIONED` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes` | string | `-` | no |
 | dynamodb_attributes | Additional DynamoDB attributes in the form of a list of mapped values | list | `<list>` | no |
 | enable_autoscaler | Flag to enable/disable DynamoDB autoscaling | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ resource "null_resource" "local_secondary_index_names" {
 resource "aws_dynamodb_table" "default" {
   count            = "${var.enabled == "true" ? 1 : 0 }"
   name             = "${module.dynamodb_label.id}"
+  billing_mode     = "${var.billing_mode}"
   read_capacity    = "${var.autoscale_min_read_capacity}"
   write_capacity   = "${var.autoscale_min_write_capacity}"
   hash_key         = "${var.hash_key}"
@@ -82,7 +83,7 @@ resource "aws_dynamodb_table" "default" {
 
 module "dynamodb_autoscaler" {
   source                       = "git::https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler.git?ref=tags/0.2.5"
-  enabled                      = "${var.enabled == "true" && var.enable_autoscaler == "true"}"
+  enabled                      = "${var.enabled == "true" && var.enable_autoscaler == "true" && var.billing_mode == "PROVISIONED"}"
   namespace                    = "${var.namespace}"
   stage                        = "${var.stage}"
   name                         = "${var.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "autoscale_max_write_capacity" {
   description = "DynamoDB autoscaling max write capacity"
 }
 
+variable "billing_mode" {
+  type        = "string"
+  default     = "PROVISIONED"
+  description = "DynamoDB Billing mode. Can be PROVISIONED or PAY_PER_REQUEST"
+}
+
 variable "enable_streams" {
   type        = "string"
   default     = "false"


### PR DESCRIPTION
Added support for `billing_mode` to select between PROVISIONED or PAY_PER_REQUEST, defaulting to PROVISIONED mode.

Also ensured that `dynamodb_autoscaler` is only created when `var.billing_mode == "PROVISIONED"`