### PR TITLE
Fix `enable_autoscaler` variable type and default

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Available targets:
 | billing_mode | DynamoDB Billing mode. Can be PROVISIONED or PAY_PER_REQUEST | string | `PROVISIONED` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | dynamodb_attributes | Additional DynamoDB attributes in the form of a list of mapped values | object | `<list>` | no |
-| enable_autoscaler | Flag to enable/disable DynamoDB autoscaling | string | `true` | no |
+| enable_autoscaler | Flag to enable/disable DynamoDB autoscaling | bool | `false` | no |
 | enable_encryption | Enable DynamoDB server-side encryption | bool | `true` | no |
 | enable_point_in_time_recovery | Enable DynamoDB point in time recovery | bool | `true` | no |
 | enable_streams | Enable DynamoDB streams | bool | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,7 +12,7 @@
 | billing_mode | DynamoDB Billing mode. Can be PROVISIONED or PAY_PER_REQUEST | string | `PROVISIONED` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | dynamodb_attributes | Additional DynamoDB attributes in the form of a list of mapped values | object | `<list>` | no |
-| enable_autoscaler | Flag to enable/disable DynamoDB autoscaling | string | `true` | no |
+| enable_autoscaler | Flag to enable/disable DynamoDB autoscaling | bool | `false` | no |
 | enable_encryption | Enable DynamoDB server-side encryption | bool | `true` | no |
 | enable_point_in_time_recovery | Enable DynamoDB point in time recovery | bool | `true` | no |
 | enable_streams | Enable DynamoDB streams | bool | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -142,8 +142,8 @@ variable "ttl_attribute" {
 }
 
 variable "enable_autoscaler" {
-  type        = string
-  default     = "true"
+  type        = bool
+  default     = false
   description = "Flag to enable/disable DynamoDB autoscaling"
 }
 


### PR DESCRIPTION
## what
* Fix `enable_autoscaler` variable type and default

## why
* Type "string" is a leftover from TF 0.11
* No need to enable autoscaler by default


