### PR TITLE
allow to add additional attributes and tags to autoscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Available targets:
 | autoscale\_min\_write\_capacity | DynamoDB autoscaling min write capacity | `number` | `5` | no |
 | autoscale\_read\_target | The target value (in %) for DynamoDB read autoscaling | `number` | `50` | no |
 | autoscale\_write\_target | The target value (in %) for DynamoDB write autoscaling | `number` | `50` | no |
+| autoscaler\_attributes | Additional attributes for the autoscaler module | `list(string)` | `[]` | no |
+| autoscaler\_tags | Additional resource tags for the autoscaler module | `map(string)` | `{}` | no |
 | billing\_mode | DynamoDB Billing mode. Can be PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PROVISIONED"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | dynamodb\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | <pre>list(object({<br>    name = string<br>    type = string<br>  }))</pre> | `[]` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -59,5 +58,3 @@
 | table\_name | DynamoDB table name |
 | table\_stream\_arn | DynamoDB table stream ARN |
 | table\_stream\_label | DynamoDB table stream label |
-
-<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -24,6 +25,8 @@
 | autoscale\_min\_write\_capacity | DynamoDB autoscaling min write capacity | `number` | `5` | no |
 | autoscale\_read\_target | The target value (in %) for DynamoDB read autoscaling | `number` | `50` | no |
 | autoscale\_write\_target | The target value (in %) for DynamoDB write autoscaling | `number` | `50` | no |
+| autoscaler\_attributes | Additional attributes for the autoscaler module | `list(string)` | `[]` | no |
+| autoscaler\_tags | Additional resource tags for the autoscaler module | `map(string)` | `{}` | no |
 | billing\_mode | DynamoDB Billing mode. Can be PROVISIONED or PAY\_PER\_REQUEST | `string` | `"PROVISIONED"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | dynamodb\_attributes | Additional DynamoDB attributes in the form of a list of mapped values | <pre>list(object({<br>    name = string<br>    type = string<br>  }))</pre> | `[]` | no |
@@ -58,3 +61,5 @@
 | table\_name | DynamoDB table name |
 | table\_stream\_arn | DynamoDB table stream ARN |
 | table\_stream\_label | DynamoDB table stream label |
+
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -127,8 +127,8 @@ module "dynamodb_autoscaler" {
   environment                  = var.environment
   name                         = var.name
   delimiter                    = var.delimiter
-  attributes                   = var.attributes
-  tags                         = module.dynamodb_label.tags
+  attributes                   = concat(var.attributes, var.autoscaler_attributes)
+  tags                         = merge(module.dynamodb_label.tags, var.autoscaler_tags)
   dynamodb_table_name          = join("", aws_dynamodb_table.default.*.id)
   dynamodb_table_arn           = join("", aws_dynamodb_table.default.*.arn)
   dynamodb_indexes             = null_resource.global_secondary_index_names.*.triggers.name

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,18 @@ variable "enable_autoscaler" {
   description = "Flag to enable/disable DynamoDB autoscaling"
 }
 
+variable "autoscaler_attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes for the autoscaler module"
+}
+
+variable "autoscaler_tags" {
+  type        = list(string)
+  default     = []
+  description = "Additional resource tags for the autoscaler module"
+}
+
 variable "dynamodb_attributes" {
   type = list(object({
     name = string

--- a/variables.tf
+++ b/variables.tf
@@ -154,8 +154,8 @@ variable "autoscaler_attributes" {
 }
 
 variable "autoscaler_tags" {
-  type        = list(string)
-  default     = []
+  type        = map(string)
+  default     = {}
   description = "Additional resource tags for the autoscaler module"
 }
 


### PR DESCRIPTION
## what
This is to avoid adding a region prefix to dynamodb tables because the autoscaler IAM role requires additional region indicator in its names

## why
- IAM policies and roles need to be unique
- DynamoDB tables should not have a region indicator as they are regional
