### PR TITLE
ensure we can take v3 of the aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,19 +197,20 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 
 ## Inputs
@@ -258,6 +259,7 @@ Available targets:
 | table\_stream\_arn | DynamoDB table stream ARN |
 | table\_stream\_label | DynamoDB table stream label |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,16 +1,17 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 
 ## Inputs
@@ -59,3 +60,4 @@
 | table\_stream\_arn | DynamoDB table stream ARN |
 | table\_stream\_label | DynamoDB table stream label |
 
+<!-- markdownlint-restore -->

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws  = "=> 2.0"
+    aws  = "~> 3.0"
     null = "~> 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws  = "~> 2.0"
+    aws  = "=> 2.0"
     null = "~> 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws  = "~> 3.0"
-    null = "~> 2.0"
+    aws    = ">= 3.0, < 4.0"
+    null   = "~> 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws    = ">= 2.0"
-    null   = "~> 2.0"
+    aws  = ">= 2.0"
+    null = "~> 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
-    aws    = ">= 3.0, < 4.0"
+    aws    = ">= 2.0"
     null   = "~> 2.0"
   }
 }


### PR DESCRIPTION
## what
do not restrict the aws provider version to just v2

## why
https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/issues/23
the aws cloud provider has v13 fixes and requirements also

## references
`closes #61 `
https://github.com/cloudposse/terraform-aws-dynamodb/issues/61
