### PR TITLE
Allow to set replica configuration on aws_dynamodb_table resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ module "dynamodb_table" {
       non_key_attributes = ["HashKey", "RangeKey"]
     }
   ]
+
+  replicas = [
+    {
+      region_name = "us-east-1"
+    }
+  ]
 }
 ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -150,6 +150,12 @@ usage: |2-
         non_key_attributes = ["HashKey", "RangeKey"]
       }
     ]
+
+    replicas = [
+      {
+        region_name = "us-east-1"
+      }
+    ]
   }
   ```
 

--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,13 @@ resource "aws_dynamodb_table" "default" {
     }
   }
 
+  dynamic "replica" {
+    for_each = var.replicas
+    content {
+      region_name = replica.value.region_name
+    }
+  }
+
   ttl {
     attribute_name = var.ttl_attribute
     enabled        = var.ttl_attribute != "" && var.ttl_attribute != null ? true : false

--- a/variables.tf
+++ b/variables.tf
@@ -186,3 +186,11 @@ variable "regex_replace_chars" {
   default     = "/[^a-zA-Z0-9-]/"
   description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
 }
+
+variable "replicas" {
+  type = list(object({
+    region_name = string
+  }))
+  default     = []
+  description = "Replica configurations in the form of a list of mapped values"
+}


### PR DESCRIPTION
## what
* This feature will allow setting `replica` configurations for `aws_dynamodb_table` resource.

## why
* According to the note at [AWS provider v3.4.0 docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_global_table), it's recommended to use `replica` configuration instead of `aws_dynamodb_global_table` resource and there is a lack of that functionality in this module.

## references
* Closes https://github.com/cloudposse/terraform-aws-dynamodb/issues/41

