### PR TITLE
Add var.ttl_enabled to support disabling ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Available targets:
 | <a name="input_stream_view_type"></a> [stream\_view\_type](#input\_stream\_view\_type) | When an item in the table is modified, what information is written to the stream | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_ttl_attribute"></a> [ttl\_attribute](#input\_ttl\_attribute) | DynamoDB table TTL attribute | `string` | `"Expires"` | no |
+| <a name="input_ttl_enabled"></a> [ttl\_enabled](#input\_ttl\_enabled) | Set to false to disable DynamoDB table TTL | `bool` | `true` | no |
 
 ## Outputs
 
@@ -327,6 +328,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -338,8 +340,6 @@ Check out these related projects.
 - [terraform-aws-elasticache-cloudwatch-sns-alarms](https://github.com/cloudposse/terraform-aws-elasticache-cloudwatch-sns-alarms) - Terraform module that configures CloudWatch SNS alerts for ElastiCache
 - [terraform-aws-rds-cluster](https://github.com/cloudposse/terraform-aws-rds-cluster) - Terraform module to provision an RDS Aurora cluster for MySQL or Postgres
 - [terraform-aws-rds](https://github.com/cloudposse/terraform-aws-rds) - Terraform module to provision AWS RDS instances
-
-
 
 ## Help
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -72,6 +72,7 @@
 | <a name="input_stream_view_type"></a> [stream\_view\_type](#input\_stream\_view\_type) | When an item in the table is modified, what information is written to the stream | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_ttl_attribute"></a> [ttl\_attribute](#input\_ttl\_attribute) | DynamoDB table TTL attribute | `string` | `"Expires"` | no |
+| <a name="input_ttl_enabled"></a> [ttl\_enabled](#input\_ttl\_enabled) | Set to false to disable DynamoDB table TTL | `bool` | `true` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_dynamodb_table" "default" {
 
   ttl {
     attribute_name = var.ttl_attribute
-    enabled        = var.ttl_attribute != "" && var.ttl_attribute != null ? true : false
+    enabled        = var.ttl_enabled
   }
 
   tags = module.this.tags

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,12 @@ variable "ttl_attribute" {
   description = "DynamoDB table TTL attribute"
 }
 
+variable "ttl_enabled" {
+  type        = bool
+  default     = true
+  description = "Set to false to disable DynamoDB table TTL"
+}
+
 variable "enable_autoscaler" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* Add `var.ttl_enabled` to support explicitly disabling dynamodb ttl on a table

## why
* Unable to disable an existing ttl configuration

## references
* Closes #84 

## Example Plan

After setting `ttl_enabled = false` w/ blank `ttl_attribute`:

```
# module.ddb_transaction_event.aws_dynamodb_table.default[0] will be updated in-place
  ~ resource "aws_dynamodb_table" "default" {
        arn              = "arn:aws:dynamodb:us-east-1:***********:table/devmw-transactionEvent"
        billing_mode     = "PAY_PER_REQUEST"
        hash_key         = "transactionId"
        id               = "devmw-transactionEvent"
        
...

        timeouts {}

      ~ ttl {
            attribute_name = "Expires"
          ~ enabled        = true -> false
        }
    }
```