### PR TITLE
Add var.enable_tags to support dynamodb-local

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_dynamodb_table" "default" {
     enabled        = var.ttl_enabled
   }
 
-  tags = module.this.tags
+  tags = var.enable_tags ? module.this.tags : null
 }
 
 module "dynamodb_autoscaler" {
@@ -123,7 +123,7 @@ module "dynamodb_autoscaler" {
   enabled = local.enabled && var.enable_autoscaler && var.billing_mode == "PROVISIONED"
 
   attributes                   = concat(module.this.attributes, var.autoscaler_attributes)
-  tags                         = merge(module.this.tags, var.autoscaler_tags)
+  tags                         = var.enable_tags ? merge(module.this.tags, var.autoscaler_tags) : null
   dynamodb_table_name          = join("", aws_dynamodb_table.default.*.id)
   dynamodb_table_arn           = join("", aws_dynamodb_table.default.*.arn)
   dynamodb_indexes             = null_resource.global_secondary_index_names.*.triggers.name

--- a/variables.tf
+++ b/variables.tf
@@ -162,3 +162,9 @@ variable "replicas" {
   default     = []
   description = "List of regions to create replica"
 }
+
+variable "enable_tags" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable tagging. This can be helpful if you're managing tables on dynamodb-local with terraform as it doesn't support tagging."
+}


### PR DESCRIPTION
## what
* Adds new variable `var.enable_tags` - defaults to `true` for backwards-compatibility
* If `var.enable_tags = false`, sets `tags = null` instead of using generated tags to support `apply` against a dynamodb-local table (which doesn't support tagging APIs)

## why
* We want to be able to use this module to manage local dynamodb tables in addition to our AWS tables

## references
* Closes #90

