### PR TITLE
Use count on autoscaler module to disable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,9 @@ resource "aws_dynamodb_table" "default" {
 module "dynamodb_autoscaler" {
   source  = "cloudposse/dynamodb-autoscaler/aws"
   version = "0.13.0"
+
+  count = local.enabled && var.enable_autoscaler && var.billing_mode == "PROVISIONED" ? 1 : 0
+
   enabled = local.enabled && var.enable_autoscaler && var.billing_mode == "PROVISIONED"
 
   attributes                   = concat(module.this.attributes, var.autoscaler_attributes)


### PR DESCRIPTION
## what
* Use `count` to disable autoscaler module if `enable_autoscaler = false`
* This guarantees the module and all sub-resources are not created

## why
* If this can't be fixed in the autoscaler module, we can handle it here

## references
* After https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler/pull/37 was merged, some autoscaler resources were automatically created, even if enable_autoscaler = false
* Closes #92

