### PR TITLE
Don't set read/write capacity in PAY_PER_REQUEST billing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -47,8 +47,8 @@ resource "aws_dynamodb_table" "default" {
   count            = local.enabled ? 1 : 0
   name             = module.this.id
   billing_mode     = var.billing_mode
-  read_capacity    = var.autoscale_min_read_capacity
-  write_capacity   = var.autoscale_min_write_capacity
+  read_capacity    = var.billing_mode == "PAY_PER_REQUEST" ? null : var.autoscale_min_read_capacity
+  write_capacity   = var.billing_mode == "PAY_PER_REQUEST" ? null : var.autoscale_min_write_capacity
   hash_key         = var.hash_key
   range_key        = var.range_key
   stream_enabled   = length(var.replicas) > 0 ? true : var.enable_streams


### PR DESCRIPTION
This causes errors at plan-time now:

```
Error: 2 errors occurred:
	* read_capacity can not be set when billing_mode is "PAY_PER_REQUEST"
	* write_capacity can not be set when billing_mode is "PAY_PER_REQUEST"

  with module.dynamodb_table.aws_dynamodb_table.default[0],
  on .terraform/modules/dynamodb_table/main.tf line 46, in resource "aws_dynamodb_table" "default":
  46: resource "aws_dynamodb_table" "default" {
```