### PR TITLE
fix: required aws provider version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Autoscaler scales up/down the provisioned OPS for the DynamoDB table based on th
 
 ## Requirements
 
-This module requires [AWS Provider](https://github.com/terraform-providers/terraform-provider-aws) `>= 1.17.0`
+This module requires [AWS Provider](https://github.com/terraform-providers/terraform-provider-aws) `>= 4.22.0`
 
 ---
 
@@ -236,14 +236,14 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules

--- a/README.yaml
+++ b/README.yaml
@@ -63,7 +63,7 @@ description: |-
 
   ## Requirements
 
-  This module requires [AWS Provider](https://github.com/terraform-providers/terraform-provider-aws) `>= 1.17.0`
+  This module requires [AWS Provider](https://github.com/terraform-providers/terraform-provider-aws) `>= 4.22.0`
 # How to use this project
 usage: |2-
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.22 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 4.22"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what
Update required aws provider version

## why
Changes introduced in https://github.com/cloudposse/terraform-aws-dynamodb/pull/107 require aws provider functionality added in https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4220-july--8-2022

This is current `terraform plan` output with old aws provider

```
Error: Unsupported argument

  on .terraform/modules/example.foo_table/main.tf line 112, in resource "aws_dynamodb_table" "default":
 112:       propagate_tags         = false

An argument named "propagate_tags" is not expected here.

Error: Unsupported argument

  on .terraform/modules/example.foo_table/main.tf line 113, in resource "aws_dynamodb_table" "default":
 113:       point_in_time_recovery = false

An argument named "point_in_time_recovery" is not expected here.
```

## references

Release notes for aws provider https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4220-july--8-2022
