### PR TITLE
Allow specifying replica configuration options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,8 +62,8 @@ resource "aws_dynamodb_table" "default" {
   write_capacity   = var.billing_mode == "PAY_PER_REQUEST" ? null : var.autoscale_min_write_capacity
   hash_key         = var.hash_key
   range_key        = var.range_key
-  stream_enabled   = length(var.replicas) > 0 ? true : var.enable_streams
-  stream_view_type = length(var.replicas) > 0 || var.enable_streams ? var.stream_view_type : ""
+  stream_enabled   = length(local.replica_configurations) > 0 ? true : var.enable_streams
+  stream_view_type = length(local.replica_configurations) > 0 || var.enable_streams ? var.stream_view_type : ""
   table_class      = var.table_class
 
 

--- a/main.tf
+++ b/main.tf
@@ -117,10 +117,10 @@ resource "aws_dynamodb_table" "default" {
   dynamic "replica" {
     for_each = local.replica_configurations
     content {
-      region_name = replica.value.region
       kms_key_arn            = replica.value.kms_key_arn
-      propagate_tags         = replica.value.propagate_tags
       point_in_time_recovery = replica.value.point_in_time_recovery
+      propagate_tags         = replica.value.propagate_tags
+      region_name            = replica.value.region
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,17 @@ variable "replicas" {
   description = "List of regions to create replica"
 }
 
+variable "replica_configurations" {
+  type = list(object({
+    kms_key_arn            = string
+    point_in_time_recovery = bool
+    propagate_tags         = bool
+    region                 = string
+  }))
+  default     = []
+  description = "List of configurations for replicas"
+}
+
 variable "tags_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what

This allows the use of a replica configuration that provides access to the underlying options available for replicas.

## why

Our compliance needs require us to have point-in-time recovery enabled for the replicas and currently it is defaulted to off.

