### PR TITLE
feat: Add tags to `aws_appautoscaling_target`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -152,7 +152,7 @@ resource "aws_dynamodb_table" "default" {
 
 module "dynamodb_autoscaler" {
   source  = "cloudposse/dynamodb-autoscaler/aws"
-  version = "0.14.0"
+  version = "0.15.0"
   enabled = local.enabled && var.enable_autoscaler && var.billing_mode == "PROVISIONED"
 
   attributes                   = concat(module.this.attributes, var.autoscaler_attributes)


### PR DESCRIPTION


## what
Update `terraform-aws-dynamodb-autoscaler` module to set tags for `aws_appautoscaling_target` resources

## references
Related PR: https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler/pull/65