### PR TITLE
fix: pass enable_point_in_time_recovery through to replica blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_dynamodb_table" "default" {
       # If kms_key_arn is null, the provider uses the default key
       kms_key_arn            = null
       propagate_tags         = false
-      point_in_time_recovery = false
+      point_in_time_recovery = var.enable_point_in_time_recovery
     }
   }
 


### PR DESCRIPTION
## what

- Pass the existing `enable_point_in_time_recovery` variable through to the `replica` block instead of hardcoding `point_in_time_recovery = false`

## why

- The hardcoded `false` force-disables PITR on global-table replicas even when `enable_point_in_time_recovery = true` is set for the primary table, and reverts any manually-enabled replica PITR on the next apply
- Compliance frameworks (e.g. SOC 2 backup requirements) generally require PITR on every region of a global table, and there is currently no way to satisfy that with this module
- Keeps primary and replica PITR consistent with a single existing variable — no interface change

## references

- `point_in_time_recovery` in the `replica` block: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#point_in_time_recovery-1